### PR TITLE
Fix empty response on sqs dequeue

### DIFF
--- a/polytope_server/common/queue/sqs_queue.py
+++ b/polytope_server/common/queue/sqs_queue.py
@@ -1,8 +1,10 @@
 import json
 import logging
-from . import queue
+
 import boto3
+
 from ..metric_collector import SQSQueueMetricCollector
+from . import queue
 
 
 class SQSQueue(queue.Queue):
@@ -30,7 +32,7 @@ class SQSQueue(queue.Queue):
             VisibilityTimeout=self.visibility_timeout,  # If processing takes more seconds, message will be read twice
             MaxNumberOfMessages=1,
         )
-        if not response["Messages"]:
+        if "Messages" not in response:
             return None
 
         msg, *remainder = response["Messages"]


### PR DESCRIPTION
Fixes the following error when the response from SQS is an empty `{}`:
```
  File "/app/polytope_server/common/queue/sqs_queue.py", line 33, in dequeue
    if not response["Messages"]:
           ~~~~~~~~^^^^^^^^^^^^
KeyError: 'Messages'
```