### PR TITLE
Enable strongly consistent read on get request

### DIFF
--- a/polytope_server/common/request_store/dynamodb_request_store.py
+++ b/polytope_server/common/request_store/dynamodb_request_store.py
@@ -182,7 +182,7 @@ class DynamoDBRequestStore(request_store.RequestStore):
         logger.info("Request ID %s removed.", id)
 
     def get_request(self, id):
-        response = self.table.get_item(Key={"id": id})
+        response = self.table.get_item(Key={"id": id}, ConsistentRead=True)
         if "Item" in response:
             return _load(response["Item"])
 


### PR DESCRIPTION
- fix the issue where a GET for a request returns 404 right after the POST has returned