### PR TITLE
use jwt_aud param when defined

### DIFF
--- a/polytope_server/common/authentication/openid_offline_access_authentication.py
+++ b/polytope_server/common/authentication/openid_offline_access_authentication.py
@@ -124,7 +124,8 @@ class OpenIDOfflineAuthentication(authentication.Authentication):
             
             user = User(token["sub"], self.realm())
 
-            roles = token.get("resource_access", {}).get(self.public_client_id, {}).get("roles", [])
+            key = self.jwt_aud if self.jwt_aud is not None else self.public_client_id
+            roles = token.get("resource_access", {}).get(key, {}).get("roles", [])
             user.roles.extend(roles)
             roles = token.get("realm_access", {}).get("roles", [])
             user.roles.extend(roles)


### PR DESCRIPTION
- use jwt_aud when defined to fetch roles from the resource_access claim
- backward compatible