### PR TITLE
Bump covjsonkit to 0.2.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 attrdict==2.0.1
 boto3==1.35.19
-git+https://github.com/ecmwf/covjsonkit.git@feature/add_cosmo_params#egg=covjsonkit
+covjsonkit==0.2.10
 deepmerge==2.0
 docker==7.1.0
 ecmwf-api-client==1.6.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 attrdict==2.0.1
 boto3==1.35.19
-covjsonkit==0.2.7
+git+https://github.com/ecmwf/covjsonkit.git@feature/add_cosmo_params#egg=covjsonkit
 deepmerge==2.0
 docker==7.1.0
 ecmwf-api-client==1.6.3


### PR DESCRIPTION
Bump covjsonkit with updated cosmo params list branch from https://github.com/ecmwf/covjsonkit/pull/103/files. Adding change to main-mch and not main so closing https://github.com/MeteoSwiss-APN/polytope-server/pull/35