### PR TITLE
Update polytope-python version to 2.1.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ opentelemetry-instrumentation-flask==0.59b0
 opentelemetry-sdk==1.38.0
 pika==1.3.2
 polytope-mars==0.3.7
-polytope-python==2.1.2
+polytope-python==2.1.9
 qubed==0.3.0
 prometheus-client==0.21.0
 py-bcrypt==0.4


### PR DESCRIPTION
Should solve the trajetory feature extraction lat/lon bug:

> Using the following feature for a request does not return any data:
> feature={
>     "type" : "trajectory",
>     "points" : [[8.565, 47.454], [6.933, 46.817], [6.143, 46.204], [8.799, 46.17]],
>     "inflation" : 0.05,
>     "inflate" : 'round',
>     "axes" : ["longitude", "latitude"],
> }
> But switching lon/lat in both axes  and points correctly returns the trajectory:
> feature={
>     "type" : "trajectory",
>     "points" : [[47.454, 8.565], [46.817, 6.933], [46.204, 6.143], [46.17, 8.799]],
>     "inflation" : 0.05,
>     "inflate" : 'round',
>     "axes" : ["latitude", "longitude"],
> }